### PR TITLE
Automatically add missing fields to the end of `export_order`.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,3 +38,4 @@ The following is a list of much appreciated contributors:
 * spookylukey (Luke Plant)
 * kane-c
 * ddiazpinto (David Díaz)
+* jeberger (Jérôme M. Berger)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -371,7 +371,8 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         return result
 
     def get_export_order(self):
-        return self._meta.export_order or self.fields.keys()
+        order = tuple (self._meta.export_order or ())
+        return order + tuple (k for k in self.fields.keys() if k not in order)
 
     def export_field(self, field, obj):
         field_name = self.get_field_name(field)

--- a/tests/core/tests/resources_tests.py
+++ b/tests/core/tests/resources_tests.py
@@ -33,6 +33,7 @@ except ImportError:
 class MyResource(resources.Resource):
     name = fields.Field()
     email = fields.Field()
+    extra = fields.Field()
 
     class Meta:
         export_order = ('email', 'name')
@@ -57,7 +58,7 @@ class ResourceTestCase(TestCase):
 
     def test_get_export_order(self):
         self.assertEqual(self.my_resource.get_export_headers(),
-                ['email', 'name'])
+                ['email', 'name', 'extra'])
 
 
 class BookResource(resources.ModelResource):


### PR DESCRIPTION
Fixes #210.