### PR TITLE
Add skip admin log option when importing

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -5,3 +5,11 @@ Settings
 ``IMPORT_EXPORT_USE_TRANSACTIONS``
     Global setting controls if resource importing should use database
     transactions. Default is ``False``.
+
+``IMPORT_EXPORT_SKIP_ADMIN_LOG``
+    Global setting controls if creating log entries for
+    the admin changelist should be skipped when importing resource.
+    The skip_admin_log attribute of `ImportMixin` is checked first,
+    which defaults to None. If not found, this global option is used.
+    This will speed up importing large datasets, but will lose
+    changing logs in the admin changelist view.  Default is ``False``.


### PR DESCRIPTION
We found out adding admin log is very slow(about 5 minutes or even more) when one csv file of about 3000 lines with about 20 columns is imported. When sqlite3 backend is in use, the import is extremely slow, it's also slow on MySQL for the log entries contains lots of plain text.