### PR TITLE
Add Python 3.4 and Django 1.8 to tox and Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   - DJANGO=1.5.5
   - DJANGO=1.6.1
   - DJANGO=1.7.0
-  - DJANGO=1.8c1
+  - DJANGO=1.8
 install:
   - pip install -q Django==$DJANGO --use-mirrors
   - pip install -e git+https://github.com/kennethreitz/tablib.git#egg=tablib

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,13 @@ language: python
 python:
   - "2.7"
   - "3.3"
+  - "3.4"
 env:
   - DJANGO=1.4.10
   - DJANGO=1.5.5
   - DJANGO=1.6.1
   - DJANGO=1.7.0
+  - DJANGO=1.8c1
 install:
   - pip install -q Django==$DJANGO --use-mirrors
   - pip install -e git+https://github.com/kennethreitz/tablib.git#egg=tablib

--- a/tox.ini
+++ b/tox.ini
@@ -64,16 +64,16 @@ deps =
 [testenv:py27-1.8]
 basepython = python2.7
 deps = 
-    django==1.8c1
+    django==1.8
 
 [testenv:py33-1.8]
 basepython = python3.3
 deps = 
-    django==1.8c1
+    django==1.8
     -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
 
 [testenv:py34-1.8]
 basepython = python3.4
 deps = 
-    django==1.8c1
+    django==1.8
     -egit+https://github.com/kennethreitz/tablib.git#egg=tablib

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26-1.4, py27-1.4, py27-tablib-dev-1.4, py27-mysql-innodb-1.4, py27-1.5, py27-1.6, py33-1.6, py27-1.7, py33-1.7
+envlist = py26-1.4, py27-1.4, py27-tablib-dev-1.4, py27-mysql-innodb-1.4, py27-1.5, py27-1.6, py33-1.6, py27-1.7, py33-1.7, py34-1.7, py27-1.8, py33-1.8, py34-1.8
 
 [testenv]
 commands=python {toxinidir}/tests/manage.py test core
@@ -53,4 +53,27 @@ deps =
 basepython = python3.3
 deps = 
     django==1.7.0
+    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
+
+[testenv:py34-1.7]
+basepython = python3.4
+deps = 
+    django==1.7.0
+    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
+
+[testenv:py27-1.8]
+basepython = python2.7
+deps = 
+    django==1.8c1
+
+[testenv:py33-1.8]
+basepython = python3.3
+deps = 
+    django==1.8c1
+    -egit+https://github.com/kennethreitz/tablib.git#egg=tablib
+
+[testenv:py34-1.8]
+basepython = python3.4
+deps = 
+    django==1.8c1
     -egit+https://github.com/kennethreitz/tablib.git#egg=tablib


### PR DESCRIPTION
As Django 1.8 is coming and the latest stable version of Python is the version 3.4.3, `tox.ini` and Travis CI should support these versions

PR related to issue #200 .