### PR TITLE
Make django 1.8 compatible

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,4 @@ The following is a list of much appreciated contributors:
 * jeberger (Jérôme M. Berger)
 * schemacs (Lele Long)
 * jbub (Juraj Bubniak)
+* ajoaoff (Antonio Francisco)

--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -13,7 +13,12 @@ from django.utils import six
 from django.db import transaction
 from django.db.models.fields import FieldDoesNotExist
 from django.db.models.query import QuerySet
-from django.db.models.related import RelatedObject
+
+try:
+    from django.db.models.related import RelatedObject
+except ImportError:
+    from django.db.models.fields.related import ForeignObjectRel as RelatedObject
+
 from django.conf import settings
 
 from .results import Error, Result, RowResult


### PR DESCRIPTION
RelatedObject no longer exists on Django 1.8. This changes makes the aplication 1.8-compatible while keeping it backwards-compatible.