### PR TITLE
fallback export_order to Meta fields definition

### DIFF
--- a/import_export/resources.py
+++ b/import_export/resources.py
@@ -371,7 +371,7 @@ class Resource(six.with_metaclass(DeclarativeMetaclass)):
         return result
 
     def get_export_order(self):
-        order = tuple (self._meta.export_order or ())
+        order = tuple (self._meta.export_order or self._meta.fields or ())
         return order + tuple (k for k in self.fields.keys() if k not in order)
 
     def export_field(self, field, obj):


### PR DESCRIPTION
Follow Resource Meta fields definition order if no specific order is
set. This is more natural and less surprising than using Model fields
order